### PR TITLE
Fixed - Callbacks do not respect configuration

### DIFF
--- a/src/HLSoft.BlazorWebAssembly.Authentication.OpenIdConnect/BlazorAuthenticationStateProvider.cs
+++ b/src/HLSoft.BlazorWebAssembly.Authentication.OpenIdConnect/BlazorAuthenticationStateProvider.cs
@@ -121,7 +121,7 @@ namespace HLSoft.BlazorWebAssembly.Authentication.OpenIdConnect
 				try
 				{
 					returnUrl = await Utils.GetAndRemoveSessionStorageData(_jsRuntime, "_returnUrl");
-					await _jsRuntime.InvokeVoidAsync(Constants.ProcessSigninCallback, clientOptions.IsCode);
+					await _jsRuntime.InvokeVoidAsync(Constants.ProcessSigninCallback, clientOptions);
 				}
 				catch (Exception err)
 				{
@@ -161,7 +161,7 @@ namespace HLSoft.BlazorWebAssembly.Authentication.OpenIdConnect
 			{
 				try
 				{
-					await _jsRuntime.InvokeVoidAsync(Constants.ProcessSigninPopup, clientOptions.IsCode);
+					await _jsRuntime.InvokeVoidAsync(Constants.ProcessSigninPopup, clientOptions);
 					RunAsyncTaskToClosePopup(1000);
 				}
 				catch (Exception err)
@@ -180,7 +180,7 @@ namespace HLSoft.BlazorWebAssembly.Authentication.OpenIdConnect
 			{
 				try
 				{
-					await _jsRuntime.InvokeVoidAsync(Constants.ProcessSignoutPopup, clientOptions.IsCode);
+					await _jsRuntime.InvokeVoidAsync(Constants.ProcessSignoutPopup, clientOptions);
 					RunAsyncTaskToClosePopup(500);
 				}
 				catch (Exception err)

--- a/src/HLSoft.BlazorWebAssembly.Authentication.OpenIdConnect/Scripts/app.js
+++ b/src/HLSoft.BlazorWebAssembly.Authentication.OpenIdConnect/Scripts/app.js
@@ -55,14 +55,14 @@
 		return mgr.signinSilent();
 	}
 
-	function createUserManager(isCode) {
-		return isCode
-			? new Oidc.UserManager(prepareOidcConfig({ loadUserInfo: true, response_mode: 'query' }))
-			: new Oidc.UserManager(prepareOidcConfig());
+	function createUserManager(config) {
+		return config.isCode
+			? new Oidc.UserManager(prepareOidcConfig({...config, loadUserInfo: true, response_mode: 'query' }))
+			: new Oidc.UserManager(prepareOidcConfig(config));
 	}
 
-	window.HLSoftBlazorWebAssemblyAuthenticationOpenIdConnect.processSigninCallback = function (isCode) {
-		let mgr = createUserManager(isCode);
+	window.HLSoftBlazorWebAssemblyAuthenticationOpenIdConnect.processSigninCallback = function (config) {
+		let mgr = createUserManager(config);
 		return mgr.signinRedirectCallback().then();
 	}
 
@@ -71,13 +71,13 @@
 		return mgr.signinSilentCallback(window.location.href);
 	}
 
-	window.HLSoftBlazorWebAssemblyAuthenticationOpenIdConnect.processSigninPopup = function (isCode) {
-		let mgr = createUserManager(isCode);
+	window.HLSoftBlazorWebAssemblyAuthenticationOpenIdConnect.processSigninPopup = function (config) {
+		let mgr = createUserManager(config);
 		return mgr.signinPopupCallback();
 	}
 
-	window.HLSoftBlazorWebAssemblyAuthenticationOpenIdConnect.processSignoutPopup = function (isCode) {
-		let mgr = createUserManager(isCode);
+	window.HLSoftBlazorWebAssemblyAuthenticationOpenIdConnect.processSignoutPopup = function (config) {
+		let mgr = createUserManager(config);
 		mgr.signoutPopupCallback(false);
 	}
 


### PR DESCRIPTION
Could not log in to Azure because `loadUserInfo` was always `true`, but I was setting it to `false` in  my configuration.  My `clientOptions` was not being passed to `createUserManager`.  

Fixed by passing `clientOptions` to `processSigninCallback`, `processSigninPopup`, and `processSignoutPopup`.



